### PR TITLE
feat: add Google Analytics tracking with next/script

### DIFF
--- a/bunk-mater/app/layout.js
+++ b/bunk-mater/app/layout.js
@@ -1,5 +1,6 @@
-import { Urbanist } from "next/font/google";
-import "./globals.css";
+import { Urbanist } from 'next/font/google';
+import './globals.css';
+import GoogleAnalytics from '@/components/google_analytics/google_analytics';
 
 const urbanist = Urbanist({ subsets: ["latin"] });
 
@@ -9,12 +10,15 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <head>
-        <link rel="icon" href="/icon.png" sizes="any" />
-      </head>
-      <body className={urbanist.className}>{children}</body>
-    </html>
-  );
+   return (
+      <html lang="en">
+         <head>
+            <link rel="icon" href="/icon.png" sizes="any" />
+         </head>
+         <body className={urbanist.className}>
+            <GoogleAnalytics/>
+            {children}
+         </body>
+      </html>
+   );
 }

--- a/bunk-mater/components/google_analytics/google_analytics.jsx
+++ b/bunk-mater/components/google_analytics/google_analytics.jsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react';
+import Script from 'next/script';
+
+const GoogleAnalytics = () => {
+  useEffect(() => {
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', process.env.NEXT_PUBLIC_GA_ID);
+  }, []);
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');
+        `}
+      </Script>
+    </>
+  );
+};
+export default GoogleAnalytics;


### PR DESCRIPTION
Closes #5

This PR integrates Google Analytics to the root `app/layout.js` of the app as a component. It ensures that the tracking script runs after the page is interactive. The GA tracking ID will now be stored in `env.local` as `NEXT_PUBLIC_GA_ID`