### PR TITLE
fix: root color in changed to be independent of color-scheme

### DIFF
--- a/bunk-mater/app/globals.css
+++ b/bunk-mater/app/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+/* :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
@@ -14,7 +14,13 @@
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }
-}
+} */
+
+:root {
+   --foreground-rgb: 255, 255, 255;
+   --background-start-rgb: 0, 0, 0;
+   --background-end-rgb: 0, 0, 0;
+ }
 
 body {
   color: rgb(var(--foreground-rgb));


### PR DESCRIPTION
Closes #7 

The root colors are changed to be independent of the browser color scheme. This choice could be subject to change in the future.